### PR TITLE
Minor changes to cluster example

### DIFF
--- a/examples/cluster/src/q_value_calculation.py
+++ b/examples/cluster/src/q_value_calculation.py
@@ -26,4 +26,4 @@ path = (
     .joinpath(f"output/example_q_dict_{experiment_setting}.pickle")
 )
 with open(path, "wb") as f:
-    pickle.dump(f, info)
+    pickle.dump(info, f)

--- a/examples/cluster/submission_scripts/q_value_calculation.sub
+++ b/examples/cluster/submission_scripts/q_value_calculation.sub
@@ -4,7 +4,7 @@ arguments = $(filename) $(experiment_setting:high_increasing) $(ground_truth_fil
 output = log/output.stdout
 error  = log/output.stderr
 log   = log/output.log
-request_memory = $(request_memory:100000)
+request_memory = 4096
 request_cpus = 1
 
 queue


### PR DESCRIPTION
(1) Request memory updated to 4096. The current submission scripts defaults to a request of 2048 MB of memory from the cluster, which causes the job to be held because it requires more memory (3000-4000).

(2) Incorrect ordering of arguments in pickle.dump() leads to error in file writing. Updated this ordering appropriately.