### PR TITLE
updated function to correctly sample termination reward

### DIFF
--- a/mouselab/mouselab.py
+++ b/mouselab/mouselab.py
@@ -150,7 +150,7 @@ class MouselabEnv(gym.Env):
 
         returns = [self.ground_truth[list(path)].sum() for path in self.optimal_paths()]
         if self.sample_term_reward:
-            return np.random.sample(returns)
+            return random.choice(returns)
         else:
             return np.mean(returns)
 


### PR DESCRIPTION
`np.random.sample()` does not select a random element from a list, but rather expects the bounds of a uniform distribution from which it returns a sample. This does not achieve the intended effect of sampling termination reward, and also errors out when this function is called, since the expected inputs to the function are integer bounds.

