### PR TITLE
added import for pathlib.Path in analysis_utils

### DIFF
--- a/mouselab/analysis_utils.py
+++ b/mouselab/analysis_utils.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 from glob import glob
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np


### PR DESCRIPTION
`analysis_utils.py` has a reference to `Path` in function `get_data`, but there's no corresponding import statement for this library, resulting in below error. Added import statement.

```
Traceback (most recent call last):
  File "mcl_toolbox/fit_mcrl_models.py", line 229, in <module>
    fit_model(
  File "mcl_toolbox/fit_mcrl_models.py", line 88, in fit_model
    mf = ModelFitter(
  File "/Volumes/DataDrive/dev_mcl_toolbox/mcl_toolbox/utils/model_utils.py", line 84, in __init__
    self.E = Experiment(self.exp_name, data_path=data_path, **exp_attributes)
  File "/Volumes/DataDrive/dev_mcl_toolbox/mcl_toolbox/utils/experiment_utils.py", line 121, in __init__
    self.data = get_data(exp_num, data_path)
  File "/Volumes/DataDrive/dev_mcl_toolbox/env/lib/python3.8/site-packages/mouselab/analysis_utils.py", line 78, in get_data
    data_path = Path(__file__).parents[2].joinpath("data/human")
NameError: name 'Path' is not defined
```